### PR TITLE
remove metric ToLogger as it is not needed

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -69,8 +69,7 @@ or component entry point the ability to provide a Logger implementation,
 this can be easily achieved.
 
 	* Zero dependencies.
-We almost succeeded, we do need Context from the Go standard library, and
-obviously we pull in this interface for our libraries and packages.
+Look at that lovely very empty go.mod and non-existent go.sum file.
 
 */
 package telemetry

--- a/metric.go
+++ b/metric.go
@@ -62,11 +62,6 @@ type Metric interface {
 	// It also allows a way to clear out LabelValues found in an attached
 	// Context if needing to sanitize.
 	With(labelValues ...LabelValue) Metric
-
-	// ToLogger takes a Logger and returns a new Logger interface which will
-	// emit an Increment() on Logger.Info and Logger.Error calls for this
-	// metric.
-	ToLogger(Logger) Logger
 }
 
 // LabelValue holds an action to take on a metric dimension's value.


### PR DESCRIPTION
To have a Logger emit metrics on `Info` and `Error` calls, use `Logger.Metric()`