### PR TITLE
adds global metricsink for lazy registration of metrics, adds noop logger

### DIFF
--- a/global_metricsink.go
+++ b/global_metricsink.go
@@ -1,0 +1,44 @@
+package telemetry
+
+import (
+	"sync"
+)
+
+// OnGlobalMetricSinkFn holds a function signature which can be used to register
+// Metric bootstrapping that needs to be called after the GlobalMetricSink has
+// been registered.
+type OnGlobalMetricSinkFn func(m MetricSink)
+
+var (
+	mtx        sync.Mutex
+	metricSink MetricSink
+	callbacks  []func(MetricSink)
+)
+
+// SetGlobalMetricSink allows one to set a global MetricSink, after which all
+// registered OnGlobalMetricSinkFn callback functions are executed.
+func SetGlobalMetricSink(ms MetricSink) {
+	mtx.Lock()
+	defer mtx.Unlock()
+
+	metricSink = ms
+	for _, callback := range callbacks {
+		callback(ms)
+	}
+	callbacks = nil
+}
+
+// ToGlobalMetricSink allows one to set callback functions to bootstrap Metrics
+// as soon as the Global MetricSink has been registered. If the MetricSink has
+// already been registered, this callback will happen immediately.
+func ToGlobalMetricSink(callback OnGlobalMetricSinkFn) {
+	mtx.Lock()
+	defer mtx.Unlock()
+
+	if metricSink != nil {
+		callback(metricSink)
+		return
+	}
+
+	callbacks = append(callbacks, callback)
+}

--- a/level/noop_logger.go
+++ b/level/noop_logger.go
@@ -1,0 +1,33 @@
+package level
+
+import (
+	"context"
+
+	"github.com/tetratelabs/telemetry"
+)
+
+// NoopLogger returns a no-op Logger.
+func NoopLogger() Logger {
+	return noopLogger{}
+}
+
+// noopLogger is a no-op logger.
+type noopLogger struct{}
+
+func (noopLogger) Debug(_ string, _ ...interface{}) {}
+
+func (noopLogger) Info(_ string, _ ...interface{}) {}
+
+func (n noopLogger) Error(_ string, _ error, _ ...interface{}) {}
+
+func (n noopLogger) With(_ ...interface{}) telemetry.Logger { return n }
+
+func (n noopLogger) Context(_ context.Context) telemetry.Logger { return n }
+
+func (n noopLogger) Metric(_ telemetry.Metric) telemetry.Logger { return n }
+
+func (noopLogger) SetLevel(_ Value) {}
+
+func (noopLogger) Level() Value { return None }
+
+func (n noopLogger) New() telemetry.Logger { return n }

--- a/noop_logger.go
+++ b/noop_logger.go
@@ -1,0 +1,22 @@
+package telemetry
+
+import "context"
+
+// NoopLogger returns a no-op logger.
+func NoopLogger() Logger {
+	return noopLogger{}
+}
+
+type noopLogger struct{}
+
+func (noopLogger) Debug(_ string, _ ...interface{}) {}
+
+func (noopLogger) Info(_ string, _ ...interface{}) {}
+
+func (n noopLogger) Error(_ string, _ error, _ ...interface{}) {}
+
+func (n noopLogger) With(_ ...interface{}) Logger { return n }
+
+func (n noopLogger) Context(_ context.Context) Logger { return n }
+
+func (n noopLogger) Metric(_ Metric) Logger { return n }


### PR DESCRIPTION
GlobalMetricSink logic allows packages to purely use the telemetry.MetricSink interface without it being passed along.

Common initialization:

```go
func main() {
	...
	telemetry.SetGlobalMetricSink(opencensus.New(
		scope.Register("metrics", "metrics related messages"),
	))
	...
}
```

Common usage:

```go
package somelib

var (
	labelStatus   telemetry.Label
	metricCounter telemetry.Metric
)

func init() {
	telemetry.ToGlobalMetricSink(func(m telemetry.MetricSink) {
		labelStatus = m.NewLabel("status")
		metricCounter = m.NewSum(
			"counter_total", 
			"description of this metric",
			telemetry.WithLabels(labelStatus).
	}
)
```