### PR TITLE
Better return type for the find signature

### DIFF
--- a/scope/scope.go
+++ b/scope/scope.go
@@ -226,12 +226,13 @@ func Register(name, description string) telemetry.Logger {
 }
 
 // Find a scoped logger by its name.
-func Find(name string) telemetry.Logger {
+func Find(name string) (telemetry.Logger, bool) {
 	lock.Lock()
 	defer lock.Unlock()
 
 	name = strings.ToLower(strings.Trim(name, "\r\n\t "))
-	return scopes[name]
+	s, ok := scopes[name]
+	return s, ok
 }
 
 // List all registered Scopes

--- a/scope/scope_test.go
+++ b/scope/scope_test.go
@@ -73,7 +73,7 @@ func TestLogger(t *testing.T) {
 			UseLogger(function.NewLogger(emitter(&out)))
 
 			_ = Register(tt.name, "test logger")
-			logger := Find(tt.name)
+			logger, _ := Find(tt.name)
 
 			logger.SetLevel(tt.level)
 			if logger.Level() != tt.level {
@@ -107,6 +107,13 @@ func TestSetLevel(t *testing.T) {
 
 	if withvalues.Level() != telemetry.LevelError {
 		t.Fatalf("logger.Level()=%v, want: %v", withvalues.Level(), telemetry.LevelError)
+	}
+}
+
+func TestFind(t *testing.T) {
+	s, ok := Find("unexisting")
+	if ok {
+		t.Fatalf("expected Find to have returned nil, got: %v", s)
 	}
 }
 


### PR DESCRIPTION
It is hard to check for nil on the currently returned interface, so we'd better return the value and boolean flag.