### PR TITLE
Allow to override default logger when it is not the same

### DIFF
--- a/scope/scope.go
+++ b/scope/scope.go
@@ -338,7 +338,8 @@ func UseLogger(logger telemetry.Logger) {
 	lock.Lock()
 	defer lock.Unlock()
 
-	if defaultLogger != nil {
+	// Skip cloning when defaultLogger is uninitialized or the given logger is the same instance.
+	if defaultLogger != nil && logger == defaultLogger {
 		return
 	}
 


### PR DESCRIPTION
When testing with multiple logger instances, the default logger (in scope) needs to be overridden (to be initialized with the cloned (of the given) logger instance). Context: https://github.com/tetratelabs/telemetry/pull/13.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>