### PR TITLE
Fix scope registration

### DIFF
--- a/scope/scope.go
+++ b/scope/scope.go
@@ -235,7 +235,7 @@ func Register(name, description string) Scope {
 			level:       &level,
 		}
 		if defaultLogger != nil {
-			sc.logger = defaultLogger.With(Key, name)
+			sc.logger = defaultLogger.Clone().With(Key, name)
 		}
 
 		scopes[name] = sc


### PR DESCRIPTION
When registering a new scope, we need to make sure we clone the default logger, if present. Otherwise, all scopes will end up sharing the same log level and it won't be able to be changed individually.
This was already addressed in the `UseLogger` method but was not taken care of during registration, making the scope level setting only work if the loggers were registered _before_ calling the `UseLogger` method.