### PR TITLE
add support for derived metrics

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# Copyright 2022 Tetrate
+# Copyright (c) Tetrate, Inc 2023.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2022 Tetrate
+# Copyright (c) Tetrate, Inc 2023.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/doc.go
+++ b/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Tetrate
+// Copyright (c) Tetrate, Inc 2023.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,10 +23,12 @@ to plug in the implementations of their choice.
 
 The following requirements helped shape the form of the interfaces.
 
-	* Simple to use!
+  - Simple to use!
+
 Or developers will resort to using `fmt.Printf()`
 
-	* No elaborate amount of logging levels.
+  - No elaborate amount of logging levels.
+
 Error: something happened that we can't gracefully recover from.
 This is a log line that should be actionable by an operator and be
 alerted on.
@@ -49,27 +51,30 @@ logger with more levels.
 We also believe that most logs should be metrics. Anything above Debug level
 should be able to emit a metric which can be use for dashboards, alerting, etc.
 
-	* Structured logging from the interface side.
+  - Structured logging from the interface side.
+
 We want the ability to rollup / aggregate over the same message while allowing
 for contextual data to be added. A logging implementation can make the choice
 how to present to provided log data. This can be 100% structured, a single log
 line, or a combination.
 
-	* Allow pass through of contextual values.
+  - Allow pass through of contextual values.
+
 Allow the Go Context object to be passed and have a registry for values of
 interest we want to pull from context. A good example of an item we want to
 automatically include in log lines is the `x-request-id` so we can tie log
 lines produced in the request path together.
 
-	* Allow each component to have their own "scope".
+  - Allow each component to have their own "scope".
+
 This allows us to control per component which levels of log lines we want
 to output at runtime. The interface design allows for this to be
 implemented without having an opinion on it. By providing at each library
 or component entry point the ability to provide a Logger implementation,
 this can be easily achieved.
 
-	* Zero dependencies.
-Look at that lovely very empty go.mod and non-existent go.sum file.
+  - Zero dependencies.
 
+Look at that lovely very empty go.mod and non-existent go.sum file.
 */
 package telemetry

--- a/function/logger.go
+++ b/function/logger.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Tetrate
+// Copyright (c) Tetrate, Inc 2023.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/function/logger_test.go
+++ b/function/logger_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Tetrate
+// Copyright (c) Tetrate, Inc 2023.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/global_metricsink.go
+++ b/global_metricsink.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Tetrate
+// Copyright (c) Tetrate, Inc 2023.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/group/service.go
+++ b/group/service.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Tetrate
+// Copyright (c) Tetrate, Inc 2023.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/group/service_test.go
+++ b/group/service_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Tetrate
+// Copyright (c) Tetrate, Inc 2023.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/level.go
+++ b/level.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Tetrate
+// Copyright (c) Tetrate, Inc 2023.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/level_test.go
+++ b/level_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Tetrate
+// Copyright (c) Tetrate, Inc 2023.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/logger.go
+++ b/logger.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Tetrate
+// Copyright (c) Tetrate, Inc 2023.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Tetrate
+// Copyright (c) Tetrate, Inc 2023.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metric.go
+++ b/metric.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Tetrate
+// Copyright (c) Tetrate, Inc 2023.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/metric.go
+++ b/metric.go
@@ -63,6 +63,23 @@ type Metric interface {
 	With(labelValues ...LabelValue) Metric
 }
 
+// DerivedMetric can be used to supply values that dynamically derive from internal
+// state, but are not updated based on any specific event. Their value will be calculated
+// based on a value func that executes when the metrics are exported.
+//
+// At the moment, only a Gauge type is supported.
+type DerivedMetric interface {
+	// Name returns the name value of a DerivedMetric.
+	Name() string
+
+	// ValueFrom is used to update the derived value with the provided
+	// function and the associated label values. If the metric is unlabeled,
+	// ValueFrom may be called without any labelValues. Otherwise, the labelValues
+	// supplied MUST match the label keys supplied at creation time both in number
+	// and in order.
+	ValueFrom(valueFn func() float64, labelValues ...LabelValue) DerivedMetric
+}
+
 // LabelValue holds an action to take on a metric dimension's value.
 type LabelValue interface{}
 
@@ -111,11 +128,24 @@ type MetricSink interface {
 	ContextWithLabels(ctx context.Context, values ...LabelValue) (context.Context, error)
 }
 
+// DerivedMetricSink bridges libraries bootstrapping metrics from metrics
+// instrumentation implementations.
+type DerivedMetricSink interface {
+	// NewDerivedGauge intents to create a new Metric with an aggregation type
+	// of LastValue. That means that data collected by the new Metric will
+	// export only the last recorded value.
+	// Unlike NewGauge, the DerivedGauge accepts functions which are called to
+	// get the current value.
+	NewDerivedGauge(name, description string) DerivedMetric
+}
+
 // MetricOption implements a functional option type for our Metrics.
 type MetricOption func(*MetricOptions)
 
 // MetricOptions hold commonly used but optional Metric configuration.
 type MetricOptions struct {
+	// EnabledCondition can hold a function which decides if metric is enabled.
+	EnabledCondition func() bool
 	// Unit holds the unit specifier of a Metric.
 	Unit Unit
 	// Labels holds the registered dimensions for the Metric.
@@ -135,5 +165,14 @@ func WithLabels(labels ...Label) MetricOption {
 func WithUnit(unit Unit) MetricOption {
 	return func(opts *MetricOptions) {
 		opts.Unit = unit
+	}
+}
+
+// WithEnabled allows a metric to be conditionally enabled if the provided
+// function returns true.
+// If disabled, metric operations will do nothing.
+func WithEnabled(enabled func() bool) MetricOption {
+	return func(opts *MetricOptions) {
+		opts.EnabledCondition = enabled
 	}
 }

--- a/metric_test.go
+++ b/metric_test.go
@@ -1,3 +1,17 @@
+// Copyright (c) Tetrate, Inc 2023.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package telemetry_test
 
 import (

--- a/metric_test.go
+++ b/metric_test.go
@@ -1,0 +1,57 @@
+package telemetry_test
+
+import (
+	"testing"
+
+	"github.com/tetratelabs/telemetry"
+)
+
+var _ telemetry.Label = (*label)(nil)
+
+type metricSink struct {
+	options telemetry.MetricOptions
+}
+
+type label string
+
+func (l label) Insert(string) telemetry.LabelValue { return nil }
+func (l label) Update(string) telemetry.LabelValue { return nil }
+func (l label) Upsert(string) telemetry.LabelValue { return nil }
+func (l label) Delete() telemetry.LabelValue       { return nil }
+
+func newMetricSink(options ...telemetry.MetricOption) *metricSink {
+	var ms metricSink
+	for _, opt := range options {
+		opt(&ms.options)
+	}
+	return &ms
+}
+
+func TestMetricOptions(t *testing.T) {
+	label1 := label("label1")
+	label2 := label("label2")
+	ms := newMetricSink(
+		telemetry.WithUnit(telemetry.Milliseconds),
+		telemetry.WithEnabled(func() bool { return true }),
+		telemetry.WithLabels(label1, label2),
+	)
+
+	if ms.options.EnabledCondition == nil {
+		t.Fatal("expected EnabledCondition to hold a function")
+	}
+	if !ms.options.EnabledCondition() {
+		t.Errorf("expected EnabledCondition function to return true")
+	}
+	if ms.options.Unit != telemetry.Milliseconds {
+		t.Errorf("expected Unit to be ms (milliseconds)")
+	}
+	if len(ms.options.Labels) != 2 {
+		t.Fatalf("unexpected label count: want: 2, have: %d", len(ms.options.Labels))
+	}
+	if ms.options.Labels[0] != label1 {
+		t.Errorf("[0] unexpected label value: want: %s, have: %s", label1, ms.options.Labels[0].(label))
+	}
+	if ms.options.Labels[1] != label2 {
+		t.Errorf("[1] unexpected label value: want: %s, have: %s", label2, ms.options.Labels[1].(label))
+	}
+}

--- a/noop.go
+++ b/noop.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Tetrate
+// Copyright (c) Tetrate, Inc 2023.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/noop_test.go
+++ b/noop_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Tetrate
+// Copyright (c) Tetrate, Inc 2023.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scope/scope.go
+++ b/scope/scope.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Tetrate
+// Copyright (c) Tetrate, Inc 2023.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/scope/scope_test.go
+++ b/scope/scope_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Tetrate
+// Copyright (c) Tetrate, Inc 2023.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
DerivedMetric can be used to supply values that dynamically derive from internal state, but are not updated based on any specific event. Their value will be calculated based on a value func that executes when the metrics are exported.