### PR TITLE
Fix level in noop logger

### DIFF
--- a/noop.go
+++ b/noop.go
@@ -18,17 +18,19 @@ import "context"
 
 // NoopLogger returns a no-op logger.
 func NoopLogger() Logger {
-	return noopLogger{}
+	return &noopLogger{level: LevelNone}
 }
 
-type noopLogger struct{}
+type noopLogger struct {
+	level Level
+}
 
-func (noopLogger) Debug(string, ...interface{})          {}
-func (noopLogger) Info(string, ...interface{})           {}
+func (*noopLogger) Debug(string, ...interface{})         {}
+func (*noopLogger) Info(string, ...interface{})          {}
 func (n noopLogger) Error(string, error, ...interface{}) {}
-func (n noopLogger) SetLevel(Level)                      {}
-func (n noopLogger) Level() Level                        { return LevelNone }
-func (n noopLogger) With(...interface{}) Logger          { return n }
-func (n noopLogger) Context(context.Context) Logger      { return n }
-func (n noopLogger) Metric(Metric) Logger                { return n }
-func (n noopLogger) Clone() Logger                       { return NoopLogger() }
+func (n *noopLogger) SetLevel(l Level)                   { n.level = l }
+func (n *noopLogger) Level() Level                       { return n.level }
+func (n *noopLogger) With(...interface{}) Logger         { return n }
+func (n *noopLogger) Context(context.Context) Logger     { return n }
+func (n *noopLogger) Metric(Metric) Logger               { return n }
+func (n *noopLogger) Clone() Logger                      { return NoopLogger() }

--- a/noop_test.go
+++ b/noop_test.go
@@ -39,9 +39,13 @@ func TestNoopLogger(t *testing.T) {
 			l := NoopLogger().Context(ctx).Metric(&metric).With().With("lvl", LevelInfo).With("missing")
 
 			tt.logfunc(l)
-
 			if metric.count != 0 {
 				t.Fatalf("metric.count=%v, want 0", metric.count)
+			}
+
+			l.SetLevel(LevelDebug)
+			if l.Level() != LevelDebug {
+				t.Fatalf("l.Level()=%v, want LevelDebug", l.Level())
 			}
 		})
 	}


### PR DESCRIPTION
Without this the Noop logger behaves in weird ways when used within the scope registration system.